### PR TITLE
Replace Host with same node replacements using two maintenance node 

### DIFF
--- a/roles/replace_node/tasks/peers.yml
+++ b/roles/replace_node/tasks/peers.yml
@@ -7,6 +7,14 @@
   register: old_node_uuid
   run_once: true
 
+- name: Fetch the cluster_node UUID of the cluster node 2
+  shell: >
+    gluster peer status |
+    grep -A1 {{ gluster_maintenance_cluster_node_2 | mandatory }} |
+    awk -F: '/uid/ { print $2}'
+  register: cluster_node_uuid
+  run_once: true
+
 - name: Get the UUID of master
   shell: awk -F= '/UUID/{print $2}' "{{ glusterd_libdir }}/glusterd.info"
   register: master_uuid
@@ -16,6 +24,44 @@
   set_fact:
     old_uuid: "{{ old_node_uuid.stdout | trim }}"
     master_uuid: "{{ master_uuid.stdout }}"
+    cluster_uuid: "{{ cluster_node_uuid.stdout | trim }}"
+
+- name: Copy the details of peers from cluster_node 2
+  fetch:
+    src: "{{ glusterd_libdir }}/peers/{{ master_uuid }}"
+    dest: /tmp/peers/
+    flat: yes
+  delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
+
+- name: Copy the details of the old node
+  fetch:
+    src: "{{ glusterd_libdir }}/peers/{{ cluster_uuid }}"
+    dest: /tmp/peers/
+    flat: yes
+  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+
+- name: stop the gluster service
+  shell: >
+    systemctl stop glusterd
+  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+
+- name: Delete the glusterd library from the old host
+  file:
+    path: "{{ glusterd_libdir }}"
+    state: absent
+  delegate_to: "{{ gluster_maintenance_old_node }}"
+
+- name: Restart glusterd
+  shell: >
+    systemctl restart glusterd
+  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+
+- pause: seconds=15
+
+- name: stop the gluster service
+  shell: >
+    systemctl stop glusterd
+  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
 - name: Edit the new node's gluster.info
   lineinfile:
@@ -24,28 +70,22 @@
     line: "UUID={{ old_uuid }}"
   delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
-- name: Copy the peer data into local
-  synchronize:
-    mode: pull
-    src: "{{ glusterd_libdir }}/peers"
-    dest: "{{ peer_tmp_dir }}"
-  run_once: true
+- name: Copy the peer data to new node
+  copy:
+    src: "{{ item }}"
+    dest: "{{ glusterd_libdir }}/peers/"
+  with_fileglob:
+    - /tmp/peers/*
+  delegate_to: "{{ gluster_maintenance_new_node }}"
 
-- name: Copy the peer data of master node
-  fetch:
-    flat: yes
-    src: "{{ glusterd_libdir }}/peers/{{ master_uuid }}"
-    dest: "{{ peer_tmp_dir }}/peers/{{ master_uuid }}"
+- name: Delete temp directory
+  file:
+    path: "/tmp/peers/"
+    state: absent
   delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
 
-- name: Delete the peer of the old node
-  file:
-    state: absent
-    path: "{{ peer_tmp_dir }}/peers/{{ old_uuid }}"
-  delegate_to: 127.0.0.1
+- name: Start glusterd service
+  shell: >
+    systemctl start glusterd
+  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
-- name: Copy the peer data to remote node
-  copy:
-    src: "{{ peer_tmp_dir }}/peers/"
-    dest: "{{ glusterd_libdir }}/peers"
-  delegate_to: "{{ gluster_maintenance_new_node }}"


### PR DESCRIPTION
These changes
1) ovirt_hosts is replaced with ovirt_host because [it has been replaced with latter](https://docs.ansible.com/ansible/latest/modules/ovirt_host_info_module.html)

2) the peers.yml change represents replacing host using 2 nodes rather than one so that the the node which is to be replaced is not even accessed, (because sometimes it could be corrupted)

The role requires 3 parameters and a condition of gluster being supported in the cluster
and a minimum number of 3 host in the same gluster supported cluster
needs to be satisfied to run the playbook

(i)   the oldNode: the node which is needed to reinstalled
(ii)  the clusterNode_1: the maintenance node
(iii) the clusterNode_2: the second maintenance node

What the roles does :-

The role basically deletes the existing gluster directory and remove the affected node from the gluster peer network. The role then gets the peer info and other details of the corrupted node from the other two nodes and reconfigure it, and then add it back to the gluster peer network, after which self heal happens and all the nodes will be in sync.

3) A condition has been put in main.yml that checks if the necessary variables have been defined in the playbook to run the replace host yml files