### PR TITLE
Implemented peer restoration logic that works for more than 3 nodes in a gluster cluster

### DIFF
--- a/roles/replace_node/tasks/peers.yml
+++ b/roles/replace_node/tasks/peers.yml
@@ -7,6 +7,10 @@
   register: old_node_uuid
   run_once: true
 
+- name: Fail if parsed hostname is different from the back-end FQDN
+  fail: msg="Hostname mentioned in inventory should be same with back-end gluster FQDN"
+  when: old_node_uuid.stdout == ""
+
 - name: Fetch the cluster_node UUID of the cluster node 2
   shell: >
     gluster peer status |
@@ -26,18 +30,20 @@
     master_uuid: "{{ master_uuid.stdout }}"
     cluster_uuid: "{{ cluster_node_uuid.stdout | trim }}"
 
-- name: Copy the details of peers from cluster_node 2
-  fetch:
-    src: "{{ glusterd_libdir }}/peers/{{ master_uuid }}"
+- name: Copy all the peers from cluster_node 2
+  copy:
+    src: "{{ item }}"
     dest: /tmp/peers/
-    flat: yes
+  with_fileglob:
+    - "{{ glusterd_libdir }}/peers/*"
   delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
 
-- name: Copy the details of the old node
-  fetch:
-    src: "{{ glusterd_libdir }}/peers/{{ cluster_uuid }}"
+- name: Copy all the peers from cluster node
+  copy:
+    src: "{{ item }}"
     dest: /tmp/peers/
-    flat: yes
+  with_fileglob:
+    - "{{ glusterd_libdir }}/peers/*"
   delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
 
 - name: stop the gluster service
@@ -63,13 +69,19 @@
     systemctl stop glusterd
   delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
-- name: Edit the new node's gluster.info
+- name: Edit the new node's glusterd.info
   lineinfile:
     path: "{{ glusterd_libdir }}/glusterd.info"
     regexp: '^UUID='
     line: "UUID={{ old_uuid }}"
   delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
+- name: Remove the old node uuid from the extracted peer details
+  file:
+    path: "{{ peer_tmp_dir }}/{{ old_uuid }}"
+    state: absent
+  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+  
 - name: Copy the peer data to new node
   copy:
     src: "{{ item }}"


### PR DESCRIPTION
The problem with the existing version was that it was working only for n=3 nodes, this was a problem because, we have cases that go up to 6 or even 12 nodes, so in that scenario, the existing implementation will not work.
So the new implementation accommodates reconfigure Gluster for nodes which are greater than n>=3,. i.e it can now handle for nodes which even has 12 or more.
The way of implementation follows a mathematical set union:-

Host 1 {gluster peer files} UNION Host 2 {gluster peer files} MINUS { old node peer file}

the resultant set of gluster peer from the above equation is our expected gluster peer list, and it will be copied to the new node, and then gluster daemon would be activated. This new way of implementation does not require any modification to the playbook, it still takes only 2 cluster maintenance host and the old to be replaced host.
RHBZ#1840003
Signed-off-by: Prajith Kesava Prasad pkesavap@redhat.com
