### PR TITLE
Implementation of authorization

### DIFF
--- a/roles/replace_node/tasks/authorization.yml
+++ b/roles/replace_node/tasks/authorization.yml
@@ -1,0 +1,25 @@
+- name: Create temp directory for authorization files
+  file:
+    path: /tmp/authorized
+    state: directory
+  delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
+
+- name: Fetch the authorized keys from the cluster node
+  copy:
+    src: "~/.ssh/authorized_keys"
+    dest: /tmp/authorized/
+  delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
+
+- name: Copying the authorized keys to the new node
+  copy:
+    src: "{{ item }}"
+    dest: "~/.ssh/"
+  with_fileglob:
+    - /tmp/authorized/*
+  delegate_to: "{{ gluster_maintenance_new_node }}"
+
+- name: Delete temp directory
+  file:
+    path: "/tmp/authorized"
+    state: absent
+  delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"


### PR DESCRIPTION
Implementing authorization to the new host,

1) The new host, if completely reset or like reinstalled with new ISO might not contain the proper authorized_keys, that would make it a problem while adding it back to the cluster.
so this copies the authorized_keys to the new host from one of the cluster_node
Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>