### PR TITLE
Bug fixes and addition of flexibility to replace different FQDN

### DIFF
--- a/roles/replace_node/tasks/main.yml
+++ b/roles/replace_node/tasks/main.yml
@@ -1,13 +1,39 @@
 ---
-# Currently we support only same node replacement.
-# Change remove this when we enhance the role
+# Validate if replace host is possible
+- name: Validating the state of the old host
+  block:
+    - name: Fetch the UUID of the old node
+      shell: >
+        gluster peer status |
+        grep -A1 {{ gluster_maintenance_old_node | mandatory }} |
+        awk -F: '/uid/ { print $2}'
+      register: uuid
+
+    - name: Get the state from peer file
+      shell: grep state "/var/lib/glusterd/peers/{{ uuid.stdout | trim }}"
+      register: grepres1
+
+    - name: Get the state from the peer command
+      shell: >
+        gluster peer status | 
+        grep -A1 {{ uuid.stdout | trim }} | 
+        grep Connected |
+        wc -l
+      ignore_errors: true
+      register: grepres2
+
+    - fail:
+        msg: "{{ gluster_maintenance_old_node }} is already in connected state"
+      when: grepres1.stdout == "state=3" and grepres2.stdout == "1"
+  run_once: true
+
 # Create tmp dir for storing peer data
 - name: Create temporary storage directory
   tempfile:
     state: directory
     suffix: _peer
   register: tmpdir
-  delegate_to: 127.0.0.1
+  delegate_to: localhost
   run_once: True
 
 # Set the glusterd location
@@ -16,27 +42,37 @@
     glusterd_libdir: "/var/lib/glusterd"
     peer_tmp_dir: "{{ tmpdir['path'] }}"
 
-
+# Copies the authorized_keys file to the new node
 - import_tasks: authorization.yml
   when: gluster_maintenance_old_node is defined and
         gluster_maintenance_cluster_node is defined and
         gluster_maintenance_cluster_node_2 is defined
 
+# Peer restoration
 - import_tasks: peers.yml
   when: gluster_maintenance_old_node is defined and 
         gluster_maintenance_cluster_node is defined and
-        gluster_maintenance_cluster_node_2 is defined
+        gluster_maintenance_cluster_node_2 is defined 
 
+# volume restoration
 - import_tasks: volume.yml
   when: gluster_maintenance_old_node is defined and
         gluster_maintenance_cluster_node is defined and
         gluster_maintenance_cluster_node_2 is defined
 
+# Detach the old host, to replace host with different FQDN usecase
+- name: Detach the peer, in the case of different host replacement
+  gluster_peer:
+    state: absent
+    force: true 
+    nodes:
+      - "{{ gluster_maintenance_old_node }}"
+  when: gluster_maintenance_old_node != gluster_maintenance_new_node
+  
 # Ensure to delete the temporary directory
 - name: Delete the temporary directory
   file:
     state: absent
     path: "{{ peer_tmp_dir }}"
-  delegate_to: 127.0.0.1
+  delegate_to: localhost 
   run_once: True
-

--- a/roles/replace_node/tasks/peers.yml
+++ b/roles/replace_node/tasks/peers.yml
@@ -1,5 +1,5 @@
 ---
-- name: Fetch the UUID of the old node
+- name: Get the UUID of the old node
   shell: >
     gluster peer status |
     grep -A1 {{ gluster_maintenance_old_node | mandatory }} |
@@ -11,93 +11,101 @@
   fail: msg="Hostname mentioned in inventory should be same with back-end gluster FQDN"
   when: old_node_uuid.stdout == ""
 
-- name: Fetch the cluster_node UUID of the cluster node 2
-  shell: >
-    gluster peer status |
-    grep -A1 {{ gluster_maintenance_cluster_node_2 | mandatory }} |
-    awk -F: '/uid/ { print $2}'
-  register: cluster_node_uuid
-  run_once: true
+# Following tasks are applicable only for replacing with different FQDN
+- name: Peer restoration in the case of replacing with different FQDN
+  block:
+    # probe the new host, if new host is not the same old host
+    - name: Peer probe the new host
+      gluster_peer:
+        state: present
+        nodes:
+          - "{{ gluster_maintenance_new_node }}"
 
-- name: Get the UUID of master
-  shell: awk -F= '/UUID/{print $2}' "{{ glusterd_libdir }}/glusterd.info"
-  register: master_uuid
-  run_once: true
+    # Workaround for Gluster Bug doesn't copy the peer file in rejected state
+    - name: Workaround for the bug to copy peer file of reject node
+      copy:
+        src: "{{ glusterd_libdir }}/peers/{{ old_node_uuid.stdout | trim }}"
+        dest: "{{ glusterd_libdir }}/peers/"
+      delegate_to: "{{ gluster_maintenance_new_node }}"
 
-- name: Store the UUID
-  set_fact:
-    old_uuid: "{{ old_node_uuid.stdout | trim }}"
-    master_uuid: "{{ master_uuid.stdout }}"
-    cluster_uuid: "{{ cluster_node_uuid.stdout | trim }}"
+    - name: Restart glusterd on the new node
+      service:
+        name: glusterd
+        state: restarted
+      delegate_to: "{{ gluster_maintenance_new_node }}"
+  when: gluster_maintenance_old_node != gluster_maintenance_new_node
 
-- name: Copy all the peers from cluster_node 2
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/peers/
-  with_fileglob:
-    - "{{ glusterd_libdir }}/peers/*"
-  delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
+# Following tasks are applicable only for replacing with same FQDN
+- name: Peer restoration in the case of replacing with same FQDN
+  block:
+    - name: Get the UUID of the current node
+      shell: >
+        cat "{{ glusterd_libdir }}"/glusterd.info |
+        awk -F= '/UUID/ { print $2}'
+      register: current_node_uuid
+      run_once: true
 
-- name: Copy all the peers from cluster node
-  copy:
-    src: "{{ item }}"
-    dest: /tmp/peers/
-  with_fileglob:
-    - "{{ glusterd_libdir }}/peers/*"
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+    - name: Fail if current node UUID is empty 
+      fail: msg="Execute this playbook on the active host"
+      when: current_node_uuid.stdout == ""
 
-- name: stop the gluster service
-  shell: >
-    systemctl stop glusterd
-  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+    - name: Store the UUID
+      set_fact:
+        old_uuid: "{{ old_node_uuid.stdout | trim }}"
+        current_uuid: "{{ current_node_uuid.stdout | trim }}"
 
-- name: Delete the glusterd library from the old host
-  file:
-    path: "{{ glusterd_libdir }}"
-    state: absent
-  delegate_to: "{{ gluster_maintenance_old_node }}"
+    - name: Collect all the peer files from cluster_node
+      copy:
+        src: "{{ glusterd_libdir }}/peers/"
+        dest: "{{ peer_tmp_dir }}/"
+      delegate_to: "{{ gluster_maintenance_cluster_node }}"
 
-- name: Restart glusterd
-  shell: >
-    systemctl restart glusterd
-  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+    - name: Check whether peer file of cluster_node is available
+      stat:
+        path: "{{ glusterd_libdir }}/peers/{{ current_uuid }}"
+      register: peerfileres
+      delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}" 
 
-- pause: seconds=15
+    - name: Fetch the peer file of the current node  
+      fetch:
+        src: "{{ glusterd_libdir }}/peers/{{ current_uuid }}"
+        dest: "{{ peer_tmp_dir }}/"
+        flat: yes
+      delegate_to: "{{ gluster_maintenance_cluster_node_2 | mandatory }}"
+      when: peerfileres.stat.isreg is defined
 
-- name: stop the gluster service
-  shell: >
-    systemctl stop glusterd
-  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+    - name: Fetch the peer file of the current node  
+      fetch:
+        src: "{{ glusterd_libdir }}/peers/{{ current_uuid }}"
+        dest: "{{ peer_tmp_dir }}/"
+        flat: yes
+      delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+      when: peerfileres.stat.isreg is not defined
 
-- name: Edit the new node's glusterd.info
-  lineinfile:
-    path: "{{ glusterd_libdir }}/glusterd.info"
-    regexp: '^UUID='
-    line: "UUID={{ old_uuid }}"
-  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+    - name: Remove the old node uuid from the extracted peer details
+      file:
+        path: "{{ peer_tmp_dir }}/{{ old_uuid }}"
+        state: absent
+      delegate_to: "{{ gluster_maintenance_cluster_node }}"
 
-- name: Remove the old node uuid from the extracted peer details
-  file:
-    path: "{{ peer_tmp_dir }}/{{ old_uuid }}"
-    state: absent
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+    - name: Copy all the peer files to the new host
+      copy:
+        src: "{{ peer_tmp_dir }}/"
+        dest: "{{ glusterd_libdir }}/peers/"
+      delegate_to: "{{ gluster_maintenance_new_node }}"
   
-- name: Copy the peer data to new node
-  copy:
-    src: "{{ item }}"
-    dest: "{{ glusterd_libdir }}/peers/"
-  with_fileglob:
-    - /tmp/peers/*
-  delegate_to: "{{ gluster_maintenance_new_node }}"
+    - name: Edit the new node's glusterd.info
+      lineinfile:
+        path: "{{ glusterd_libdir }}/glusterd.info"
+        regexp: '^UUID='
+        line: "UUID={{ old_uuid }}"
+      delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
-- name: Delete temp directory
-  file:
-    path: "/tmp/peers/"
-    state: absent
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+    - name: Restart glusterd
+      service:
+        name: glusterd
+        state: restarted
+      delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
 
-- name: Start glusterd service
-  shell: >
-    systemctl start glusterd
-  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
-
+    - pause: seconds=5
+  when: gluster_maintenance_old_node == gluster_maintenance_new_node

--- a/roles/replace_node/tasks/volume.yml
+++ b/roles/replace_node/tasks/volume.yml
@@ -17,36 +17,15 @@
       with_items: "{{ volumes }}"
       register: brick_list
 
-    - set_fact:
-        volume_bricks: {}
-
-    - name: Get the list of bricks into a variable
-      set_fact:
-        volume_bricks: "{{ volume_bricks|combine({item.item: item.stdout}) }}"
-      loop: "{{ brick_list.results }}"
   delegate_to: "{{ gluster_maintenance_cluster_node }}"
   
 - name: Run replace-brick commit on the brick
   shell: >
-    gluster volume replace-brick {{ item.key }}
-    {{gluster_maintenance_old_node}}:{{item.value}}
-    {{gluster_maintenance_new_node}}:{{item.value}}
+    gluster volume replace-brick {{ item.0.item }}
+    {{gluster_maintenance_old_node}}:{{item.1}}
+    {{gluster_maintenance_new_node}}:{{item.1}}
     commit force
-  loop: "{{ lookup('dict', volume_bricks) }}"
+  with_subelements: 
+    - "{{ brick_list.results }}"
+    - stdout_lines
   delegate_to: "{{ gluster_maintenance_cluster_node }}"
-
-- name: Start glusterd on new node
-  service:
-    name: glusterd
-    state: restarted
-  delegate_to: "{{ gluster_maintenance_new_node }}"
-
-# Somehow resetting the bricks and restarting glusterd does not start
-# the brick processes. Start the brick processes.
-# Can't use the gluster_volume module, it does not support foce for
-# starting volumes
-- name: Run volume start force to bring up brick processes
-  shell: >
-    gluster volume start {{ item }} force
-  with_items: "{{ volumes }}"
-


### PR DESCRIPTION
This patch is significant, as it adds fixes and also new feature of replacing the host with different FQDN too. I have verified the same in my setup. Following are the details:
   
 1. Validation whether the old node is not in connected state
  2. Enabled replacement of host with different FQDN as well.
  3. Fixes the semantic issue with peer files copy to new node
  4. Fixes replace-brick logic for Nx3 volumes