### PR TITLE
Fixed few problems with replace_host workflow and added flexibility to activate host in oVirt Admin Portal

### DIFF
--- a/roles/replace_node/tasks/activate_host.yml
+++ b/roles/replace_node/tasks/activate_host.yml
@@ -1,0 +1,60 @@
+---
+# Get the primary-volfile-server hostname
+- name: Get the primary volfile server hostname
+  shell: df -Th | grep fuse.glusterfs | cut -d ':' -f1 | uniq
+  register: hostnameres
+
+- name: register primary volfile server
+  set_fact:
+    volfile_server: "{{ hostnameres.stdout | trim }}"
+
+# Get the auth to RHV/oVirt Manager
+- name: Obtain SSO token with using username/password credentials
+  ovirt_auth:
+    url: https://{{ ovirt_engine_hostname }}/ovirt-engine/api
+    username: admin@internal
+    password: "{{ ovirt_engine_password }}"
+
+# Activate the host in RHV/oVirt Manager 
+- name: If replacing with same host, reinstall host in RHV/oVirt
+  block:
+    # Move the host into maintenance mode
+    - name: Move the host in to maintenance node
+      ovirt_host:
+        auth: "{{ ovirt_auth }}"
+        state: maintenance
+        name: "{{ gluster_maintenance_new_node_frontend }}"
+
+    # Reinstall host using public key
+    - name: Reinstall the host with the public key
+      async: 50
+      poll: 0
+      ovirt_host:
+        state: reinstalled
+        activate: yes
+        name: "{{ gluster_maintenance_new_node_frontend }}"
+        address: "{{ gluster_maintenance_new_node_frontend }}"
+        public_key: true
+        hosted_engine: deploy
+        auth: "{{ ovirt_auth }}"
+  when: gluster_maintenance_old_node == gluster_maintenance_new_node
+
+# Add the new host in RHV/oVirt Manager 
+- name: If replacing with diff host, add that new host in RHV/oVirt
+  block:
+    # Add the new using public key
+    - name: Add the new host to cluster in RHV/oVirt Admin portal
+      async: 50
+      poll: 0
+      ignore_errors: true
+      ovirt_host:
+        cluster: "{{ ovirt_cluster }}"
+        name: "{{ gluster_maintenance_new_node_frontend }}"
+        address: "{{ gluster_maintenance_new_node_frontend }}"
+        state: present
+        public_key: true
+        auth: "{{ ovirt_auth }}"
+        hosted_engine: deploy
+  delegate_to: "{{ gluster_maintenance_cluster_node }}"
+  when: gluster_maintenance_old_node != gluster_maintenance_new_node  and
+        gluster_maintenance_old_node != volfile_server

--- a/roles/replace_node/tasks/authorization.yml
+++ b/roles/replace_node/tasks/authorization.yml
@@ -1,25 +1,11 @@
-- name: Create temp directory for authorization files
-  file:
-    path: /tmp/authorized
-    state: directory
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
-
-- name: Fetch the authorized keys from the cluster node
+- name: Make sure authorized_keys file is present
+  stat:
+    path: "/root/.ssh/authorized_keys"
+  register: authkey
+  
+- name: Copy the authorized_keys from the active host to the new host
   copy:
-    src: "~/.ssh/authorized_keys"
-    dest: /tmp/authorized/
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
-
-- name: Copying the authorized keys to the new node
-  copy:
-    src: "{{ item }}"
-    dest: "~/.ssh/"
-  with_fileglob:
-    - /tmp/authorized/*
-  delegate_to: "{{ gluster_maintenance_new_node }}"
-
-- name: Delete temp directory
-  file:
-    path: "/tmp/authorized"
-    state: absent
-  delegate_to: "{{ gluster_maintenance_cluster_node | mandatory }}"
+    src: "/root/.ssh/authorized_keys"
+    dest: "/root/.ssh/authorized_keys"
+  delegate_to: "{{ gluster_maintenance_new_node | mandatory }}"
+  when: authkey.stat.isreg is defined

--- a/roles/replace_node/tasks/main.yml
+++ b/roles/replace_node/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# Peer restoration
 # Validate if replace host is possible
 - name: Validating the state of the old host
   block:
@@ -68,7 +69,15 @@
     nodes:
       - "{{ gluster_maintenance_old_node }}"
   when: gluster_maintenance_old_node != gluster_maintenance_new_node
-  
+
+# Activate the new host in RHV/oVirt manager UI, when the required
+# engine credentials are available
+- import_tasks: activate_host.yml
+  when: gluster_maintenance_old_node is defined and
+        gluster_maintenance_cluster_node is defined and
+        gluster_maintenance_cluster_node_2 is defined and
+        activate_host is defined and activate_host
+   
 # Ensure to delete the temporary directory
 - name: Delete the temporary directory
   file:

--- a/roles/replace_node/tasks/volume.yml
+++ b/roles/replace_node/tasks/volume.yml
@@ -12,8 +12,10 @@
     # Find the list of bricks on the machine
     - name: Get the list of bricks corresponding to volume
       shell: >
-        gluster vol info {{ item }} | grep {{ gluster_maintenance_old_node }} |
-        awk -F: '{ print $3 }'
+        gluster vol info {{ item }} | 
+        grep {{ gluster_maintenance_old_node }} |
+        cut -d' ' -f2 |
+        awk -F: '{ print $2 }'
       with_items: "{{ volumes }}"
       register: brick_list
 


### PR DESCRIPTION
Fixed few problems and added the flexibility to activate the host in the RHV/oVirt Admin portal, post gluster
bricks replacement. In the case of replacing with the same FQDN,
the flow will try to reinstall the host and user needs to just activate
it. In the case of replacing with different FQDN, the new host will be
added to the same cluster.