### PR TITLE
gluster replace-brick command is invoked, only when the brick directory is not available

### DIFF
--- a/roles/replace_node/tasks/volume.yml
+++ b/roles/replace_node/tasks/volume.yml
@@ -12,21 +12,23 @@
     # Find the list of bricks on the machine
     - name: Get the list of bricks corresponding to volume
       shell: >
-        gluster vol info {{ item }} |
+        gluster vol info {{ item }} | 
         grep {{ gluster_maintenance_old_node }} |
         cut -d' ' -f2 |
         awk -F: '{ print $2 }'
       with_items: "{{ volumes }}"
       register: brick_list
-
-    - name: Run replace-brick commit on the brick
-      shell: >
-        gluster volume replace-brick {{ item.0.item }}
-        {{gluster_maintenance_old_node}}:{{item.1}}
-        {{gluster_maintenance_new_node}}:{{item.1}}
-        commit force
-      with_subelements:
-        - "{{ brick_list.results }}"
-        - stdout_lines
   delegate_to: "{{ gluster_maintenance_cluster_node }}"
-  when: gluster_maintenance_new_node != gluster_maintenance_old_node
+  
+- name: Run replace-brick commit on the brick
+  shell: >
+    [ ! -d {{item.1}} ] && gluster volume replace-brick {{ item.0.item }}
+    {{gluster_maintenance_old_node}}:{{item.1}}
+    {{gluster_maintenance_new_node}}:{{item.1}}
+    commit force
+  register: ret
+  failed_when: ret.rc >=2
+  with_subelements: 
+    - "{{ brick_list.results }}"
+    - stdout_lines
+  delegate_to: "{{ gluster_maintenance_new_node }}"


### PR DESCRIPTION
With this fix, replace-brick command is invoked only when the brick directory is not available.
If the brick directory is available, then its taken that the contents of the bricks are already available and brick process should start well with the restart of glusterd